### PR TITLE
Fixed #19

### DIFF
--- a/src/main/java/net/shinkasystems/kintai/component/PasswordDuplicateValidator.java
+++ b/src/main/java/net/shinkasystems/kintai/component/PasswordDuplicateValidator.java
@@ -41,7 +41,7 @@ public class PasswordDuplicateValidator implements IValidator<String> {
 			if (new Authentication(user.getUserName(), validatable.getValue()).getPasswordHash().equals(
 					user.getPassword())) {
 				
-				validatable.error(new ValidationError());
+				validatable.error(new ValidationError(this));;
 			}
 
 		});

--- a/src/main/java/net/shinkasystems/kintai/page/ConfigPage.html
+++ b/src/main/java/net/shinkasystems/kintai/page/ConfigPage.html
@@ -3,6 +3,10 @@
 <h1>設定</h1>
 
 
+<div wicket:id="infomation-panel">
+	<p>Infomation Panel</p>
+</div>
+
 <div wicket:id="alert-panel">
 	<p>Alert Panel</p>
 </div>

--- a/src/main/java/net/shinkasystems/kintai/page/ConfigPage.java
+++ b/src/main/java/net/shinkasystems/kintai/page/ConfigPage.java
@@ -5,6 +5,7 @@ import net.shinkasystems.kintai.KintaiSession;
 import net.shinkasystems.kintai.component.PasswordConfirmValidator;
 import net.shinkasystems.kintai.component.PasswordDuplicateValidator;
 import net.shinkasystems.kintai.panel.AlertPanel;
+import net.shinkasystems.kintai.panel.InfomationPanel;
 import net.shinkasystems.kintai.service.ConfigService;
 
 import org.apache.wicket.authroles.authorization.strategies.role.annotations.AuthorizeInstantiation;
@@ -38,6 +39,11 @@ public class ConfigPage extends DefaultLayoutPage {
 	private final Panel alertPanel = new AlertPanel("alert-panel");
 
 	/**
+	 * 情報パネルです。
+	 */
+	private final InfomationPanel infomationPanel = new InfomationPanel("infomation-panel");
+
+	/**
 	 * 設定フォームです。
 	 */
 	private final Form<ValueMap> configForm = new Form<ValueMap>("config-form") {
@@ -56,6 +62,9 @@ public class ConfigPage extends DefaultLayoutPage {
 			 * ロール（期限切れ）をリセットするために、 新しいパスワードでサインインしなおす。
 			 */
 			KintaiSession.get().signIn(((KintaiSession) KintaiSession.get()).getUser().getUserName(), password);
+
+			infomationPanel.setMessage(getString("pasword-changed"));
+			infomationPanel.setVisible(true);
 		}
 
 		@Override
@@ -92,6 +101,7 @@ public class ConfigPage extends DefaultLayoutPage {
 		 * コンポーネントの編集
 		 */
 		alertPanel.setVisible(false);
+		infomationPanel.setVisible(false);
 
 		passwordTextField.setRequired(true);
 		passwordTextField.add(StringValidator.minimumLength(8));
@@ -107,6 +117,7 @@ public class ConfigPage extends DefaultLayoutPage {
 		configForm.add(passwordTextField);
 		configForm.add(confirmTextField);
 
+		add(infomationPanel);
 		add(alertPanel);
 		add(configForm);
 	}

--- a/src/main/java/net/shinkasystems/kintai/page/ConfigPage_ja.utf8.properties
+++ b/src/main/java/net/shinkasystems/kintai/page/ConfigPage_ja.utf8.properties
@@ -1,4 +1,7 @@
 config-form.password=パスワード
 config-form.password-confirm=パスワード（確認）
 
+pasword-changed=パスワードを変更しました。
+
 PasswordConfirmValidator=パスワードが一致しません。
+PasswordDuplicateValidator=変更前のパスワードと同じです。


### PR DESCRIPTION
パスワード変更時にメッセージを出力する。

ついでに、パスワードが変更前と同じ場合、エラーメッセージが正常に表示されていなかったのでエラーを表示するよう修正した。
